### PR TITLE
Bug fix in Classes.make_links_absolute()

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -478,7 +478,7 @@ class HtmlMixin(object):
             raise ValueError(
                 "unexpected value for handle_failures: %r" % handle_failures)
 
-        self.rewrite_links(link_repl)
+        self.rewrite_links(link_repl, resolve_base_href=resolve_base_href)
 
     def resolve_base_href(self, handle_failures=None):
         """


### PR DESCRIPTION
Bug fix: If resolve_base_href flag is not passed, self.resolve_base_href() will be called again in self.rewrite_links(), ignoring user's intent.